### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Atmel Corporation
 maintainer=Matthijs Kooijman <matthijs@stdin.nl>
 sentence=Arduino port of the Lightweight Mesh stack provided by Atmel.
 paragraph=Supports lightweight mesh networking using 802.15.4 tranceivers (and microcontrollers with builtin tranceivers) from Atmel.  This library was created to support the Pinoccio Scout hardware, but should work on other hardware as well.
+category=Communication
 url=https://github.com/Pinoccio/library-atmel-lwm
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Atmel Lightweight Mesh framework is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
